### PR TITLE
changed from static to self keyword for Currency::currencies property

### DIFF
--- a/lib/Money/Currency.php
+++ b/lib/Money/Currency.php
@@ -24,7 +24,7 @@ class Currency
      */
     public function __construct($name)
     {
-        $currencies = static::getCurrencies();
+        $currencies = self::getCurrencies();
 
         if (!array_key_exists($name, $currencies)) {
             throw new UnknownCurrencyException($name);
@@ -38,11 +38,11 @@ class Currency
      */
     public static function getCurrencies()
     {
-        if(!isset(static::$currencies)) {
-            static::$currencies = require __DIR__.'/currencies.php';
+        if(!isset(self::$currencies)) {
+            self::$currencies = require __DIR__.'/currencies.php';
         }
 
-        return static::$currencies;
+        return self::$currencies;
     }
 
     /**


### PR DESCRIPTION
Changed the way of accessing the static `$currencies` property of class `Currency` from `static` to `self`. 
## Why?

It is impossible to extend class `Currency` because the `getCurrencies()` method called in the constructor tries to access the private property from the derived class. By changing it to `self` keyword it always access the property from the base class. 
